### PR TITLE
Fixed error in simultaneous use with 'Laravel Fortify'

### DIFF
--- a/src/FilamentTwoFactor.php
+++ b/src/FilamentTwoFactor.php
@@ -38,7 +38,7 @@ class FilamentTwoFactor
 
     public function hasTwoFactorEnabled($user)
     {
-        return optional($user)->hasEnabledFilamentTwoFactorAuthentication();
+        return optional($user)->hasEnabledTwoFactorAuthentication();
     }
 
     public function generateRecoveryCode()

--- a/src/TwoFactorAuthenticatable.php
+++ b/src/TwoFactorAuthenticatable.php
@@ -16,7 +16,7 @@ trait TwoFactorAuthenticatable
      *
      * @return bool
      */
-    public function hasEnabledFilamentTwoFactorAuthentication()
+    public function hasEnabledTwoFactorAuthentication()
     {
         return ! is_null($this->two_factor_secret) &&
             ! is_null($this->two_factor_confirmed_at);


### PR DESCRIPTION
When we use filament-2fa and Fortify (Jetstream,..) at the same time, we will get the error 
`Call to undefined method App\Models\User::hasEnabledTwoFactorAuthentication()`